### PR TITLE
removing-staffbot-secret-for-go-from-dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 
-registries:
-  github:
-    type: git
-    url: https://github.com
-    username: x-access-token
-    password: ${{ secrets.STAFFBOT_GO_READ }}
-
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -24,8 +17,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    registries:
-      - github
     groups:
       go-dependencies:
         patterns:


### PR DESCRIPTION
DEVS-1176

- Updated dependabot configuration in `dependabot.yml` to remove `secrets.STAFFBOT_GO_READ`
- This secret will be removed, as dependabot can now update internal Go dependencies without Staffbot as pull_collaborator.